### PR TITLE
Configurable http client

### DIFF
--- a/openid/configuration.go
+++ b/openid/configuration.go
@@ -2,5 +2,5 @@ package openid
 
 type configuration struct {
 	Issuer  string `json:"issuer"`
-	JwksUri string `json:"jwks_uri"`
+	JwksURI string `json:"jwks_uri"`
 }

--- a/openid/configurationgettermock_test.go
+++ b/openid/configurationgettermock_test.go
@@ -1,6 +1,9 @@
 package openid
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
 type configurationGetterMock struct {
 	t     *testing.T
@@ -20,7 +23,7 @@ type getConfigurationResponse struct {
 	err    error
 }
 
-func (c *configurationGetterMock) getConfiguration(iss string) (configuration, error) {
+func (c *configurationGetterMock) getConfiguration(r *http.Request, iss string) (configuration, error) {
 	c.Calls <- &getConfigurationCall{iss}
 	gr := (<-c.Calls).(*getConfigurationResponse)
 	return gr.config, gr.err

--- a/openid/configurationprovider.go
+++ b/openid/configurationprovider.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-const wellKnownOpenIdConfiguration = "/.well-known/openid-configuration"
+const wellKnownOpenIDConfiguration = "/.well-known/openid-configuration"
 
 type decodeResponseFunc func(io.Reader, interface{}) error
 
@@ -33,7 +33,7 @@ func (httpProv *httpConfigurationProvider) getConfiguration(r *http.Request, iss
 	if issuer == "accounts.google.com" {
 		issuer = "https://" + issuer
 	}
-	configurationURI := issuer + wellKnownOpenIdConfiguration
+	configurationURI := issuer + wellKnownOpenIDConfiguration
 	var config configuration
 	resp, err := httpProv.getConfig(r, configurationURI)
 	if err != nil {

--- a/openid/configurationprovider.go
+++ b/openid/configurationprovider.go
@@ -16,11 +16,11 @@ type configurationGetter interface { // Getter
 }
 
 type httpConfigurationProvider struct { //configurationProvider
-	getConfig    httpGetFunc        //httpGetter
+	getConfig    HTTPGetFunc        //httpGetter
 	decodeConfig decodeResponseFunc //responseDecoder
 }
 
-func newHTTPConfigurationProvider(gc httpGetFunc, dc decodeResponseFunc) *httpConfigurationProvider {
+func newHTTPConfigurationProvider(gc HTTPGetFunc, dc decodeResponseFunc) *httpConfigurationProvider {
 	return &httpConfigurationProvider{gc, dc}
 }
 

--- a/openid/configurationprovider.go
+++ b/openid/configurationprovider.go
@@ -9,11 +9,10 @@ import (
 
 const wellKnownOpenIdConfiguration = "/.well-known/openid-configuration"
 
-type httpGetFunc func(url string) (*http.Response, error)
 type decodeResponseFunc func(io.Reader, interface{}) error
 
 type configurationGetter interface { // Getter
-	getConfiguration(string) (configuration, error)
+	getConfiguration(r *http.Request, url string) (configuration, error)
 }
 
 type httpConfigurationProvider struct { //configurationProvider
@@ -29,22 +28,32 @@ func jsonDecodeResponse(r io.Reader, v interface{}) error {
 	return json.NewDecoder(r).Decode(v)
 }
 
-func (httpProv *httpConfigurationProvider) getConfiguration(issuer string) (configuration, error) {
+func (httpProv *httpConfigurationProvider) getConfiguration(r *http.Request, issuer string) (configuration, error) {
 	// Workaround for tokens issued by google
 	if issuer == "accounts.google.com" {
 		issuer = "https://" + issuer
 	}
-	configurationUri := issuer + wellKnownOpenIdConfiguration
+	configurationURI := issuer + wellKnownOpenIdConfiguration
 	var config configuration
-	resp, err := httpProv.getConfig(configurationUri)
+	resp, err := httpProv.getConfig(r, configurationURI)
 	if err != nil {
-		return config, &ValidationError{Code: ValidationErrorGetOpenIdConfigurationFailure, Message: fmt.Sprintf("Failure while contacting the configuration endpoint %v.", configurationUri), Err: err, HTTPStatus: http.StatusUnauthorized}
+		return config, &ValidationError{
+			Code:       ValidationErrorGetOpenIdConfigurationFailure,
+			Message:    fmt.Sprintf("Failure while contacting the configuration endpoint %v.", configurationURI),
+			Err:        err,
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	defer resp.Body.Close()
 
 	if err := httpProv.decodeConfig(resp.Body, &config); err != nil {
-		return config, &ValidationError{Code: ValidationErrorDecodeOpenIdConfigurationFailure, Message: fmt.Sprintf("Failure while decoding the configuration retrived from endpoint %v.", configurationUri), Err: err, HTTPStatus: http.StatusUnauthorized}
+		return config, &ValidationError{
+			Code:       ValidationErrorDecodeOpenIdConfigurationFailure,
+			Message:    fmt.Sprintf("Failure while decoding the configuration retrived from endpoint %v.", configurationURI),
+			Err:        err,
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	return config, nil

--- a/openid/configurationprovider_test.go
+++ b/openid/configurationprovider_test.go
@@ -39,15 +39,14 @@ func Test_getConfiguration_UsesCorrectUrlAndRequest(t *testing.T) {
 func Test_getConfiguration_WhenGetReturnsError(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{getConfig: c.httpGet}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	readError := errors.New("Read configuration error")
 	go func() {
-		c.assertHTTPGet(req, anything, nil, readError)
+		c.assertHTTPGet(nil, anything, nil, readError)
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(req, "issuer")
+	_, e := configurationProvider.getConfiguration(nil, "issuer")
 
 	expectValidationError(t, e, ValidationErrorGetOpenIdConfigurationFailure, http.StatusUnauthorized, readError)
 
@@ -57,18 +56,17 @@ func Test_getConfiguration_WhenGetReturnsError(t *testing.T) {
 func Test_getConfiguration_WhenGetSucceeds(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{c.httpGet, c.decodeResponse}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	respBody := "openid configuration"
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHTTPGet(req, anything, resp, nil)
+		c.assertHTTPGet(nil, anything, resp, nil)
 		c.assertDecodeResponse(respBody, nil, nil)
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(req, anything)
+	_, e := configurationProvider.getConfiguration(nil, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)
@@ -80,18 +78,17 @@ func Test_getConfiguration_WhenGetSucceeds(t *testing.T) {
 func Test_getConfiguration_WhenDecodeResponseReturnsError(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{c.httpGet, c.decodeResponse}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	decodeError := errors.New("Decode configuration error")
 	respBody := "openid configuration"
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHTTPGet(req, anything, resp, nil)
+		c.assertHTTPGet(nil, anything, resp, nil)
 		c.assertDecodeResponse(anything, nil, decodeError)
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(req, anything)
+	_, e := configurationProvider.getConfiguration(nil, anything)
 
 	expectValidationError(t, e, ValidationErrorDecodeOpenIdConfigurationFailure, http.StatusUnauthorized, decodeError)
 
@@ -101,18 +98,17 @@ func Test_getConfiguration_WhenDecodeResponseReturnsError(t *testing.T) {
 func Test_getConfiguration_WhenDecodeResponseSucceeds(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{c.httpGet, c.decodeResponse}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	config := &configuration{"testissuer", "https://testissuer/jwk"}
 	respBody := "openid configuration"
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHTTPGet(req, anything, resp, nil)
+		c.assertHTTPGet(nil, anything, resp, nil)
 		c.assertDecodeResponse(anything, config, nil)
 		c.close()
 	}()
 
-	rc, e := configurationProvider.getConfiguration(req, anything)
+	rc, e := configurationProvider.getConfiguration(nil, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)

--- a/openid/configurationprovider_test.go
+++ b/openid/configurationprovider_test.go
@@ -23,7 +23,7 @@ func Test_getConfiguration_UsesCorrectUrlAndRequest(t *testing.T) {
 	issuer := "https://test"
 	configSuffix := "/.well-known/openid-configuration"
 	go func() {
-		c.assertHttpGet(req, issuer+configSuffix, nil, errors.New("Read configuration error"))
+		c.assertHTTPGet(req, issuer+configSuffix, nil, errors.New("Read configuration error"))
 		c.close()
 	}()
 
@@ -43,7 +43,7 @@ func Test_getConfiguration_WhenGetReturnsError(t *testing.T) {
 
 	readError := errors.New("Read configuration error")
 	go func() {
-		c.assertHttpGet(req, anything, nil, readError)
+		c.assertHTTPGet(req, anything, nil, readError)
 		c.close()
 	}()
 
@@ -63,7 +63,7 @@ func Test_getConfiguration_WhenGetSucceeds(t *testing.T) {
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(req, anything, resp, nil)
+		c.assertHTTPGet(req, anything, resp, nil)
 		c.assertDecodeResponse(respBody, nil, nil)
 		c.close()
 	}()
@@ -86,7 +86,7 @@ func Test_getConfiguration_WhenDecodeResponseReturnsError(t *testing.T) {
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(req, anything, resp, nil)
+		c.assertHTTPGet(req, anything, resp, nil)
 		c.assertDecodeResponse(anything, nil, decodeError)
 		c.close()
 	}()
@@ -107,7 +107,7 @@ func Test_getConfiguration_WhenDecodeResponseSucceeds(t *testing.T) {
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(req, anything, resp, nil)
+		c.assertHTTPGet(req, anything, resp, nil)
 		c.assertDecodeResponse(anything, config, nil)
 		c.close()
 	}()
@@ -122,8 +122,8 @@ func Test_getConfiguration_WhenDecodeResponseSucceeds(t *testing.T) {
 		t.Error("Expected issuer", config.Issuer, "but was", rc.Issuer)
 	}
 
-	if rc.JwksUri != config.JwksUri {
-		t.Error("Expected jwks uri", config.JwksUri, "but was", rc.JwksUri)
+	if rc.JwksURI != config.JwksURI {
+		t.Error("Expected jwks uri", config.JwksURI, "but was", rc.JwksURI)
 	}
 
 	c.assertDone()

--- a/openid/configurationprovider_test.go
+++ b/openid/configurationprovider_test.go
@@ -25,7 +25,7 @@ func Test_getConfiguration_UsesCorrectUrl(t *testing.T) {
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(issuer)
+	_, e := configurationProvider.getConfiguration(nil, issuer)
 
 	if e == nil {
 		t.Error("An error was expected but not returned")
@@ -44,7 +44,7 @@ func Test_getConfiguration_WhenGetReturnsError(t *testing.T) {
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration("issuer")
+	_, e := configurationProvider.getConfiguration(nil, "issuer")
 
 	expectValidationError(t, e, ValidationErrorGetOpenIdConfigurationFailure, http.StatusUnauthorized, readError)
 
@@ -64,7 +64,7 @@ func Test_getConfiguration_WhenGetSucceeds(t *testing.T) {
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(anything)
+	_, e := configurationProvider.getConfiguration(nil, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)
@@ -86,7 +86,7 @@ func Test_getConfiguration_WhenDecodeResponseReturnsError(t *testing.T) {
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(anything)
+	_, e := configurationProvider.getConfiguration(nil, anything)
 
 	expectValidationError(t, e, ValidationErrorDecodeOpenIdConfigurationFailure, http.StatusUnauthorized, decodeError)
 
@@ -106,7 +106,7 @@ func Test_getConfiguration_WhenDecodeResponseSucceeds(t *testing.T) {
 		c.close()
 	}()
 
-	rc, e := configurationProvider.getConfiguration(anything)
+	rc, e := configurationProvider.getConfiguration(nil, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)

--- a/openid/configurationprovider_test.go
+++ b/openid/configurationprovider_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -14,18 +15,19 @@ type testBody struct {
 
 func (testBody) Close() error { return nil }
 
-func Test_getConfiguration_UsesCorrectUrl(t *testing.T) {
+func Test_getConfiguration_UsesCorrectUrlAndRequest(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{getConfig: c.httpGet}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	issuer := "https://test"
 	configSuffix := "/.well-known/openid-configuration"
 	go func() {
-		c.assertHttpGet(issuer+configSuffix, nil, errors.New("Read configuration error"))
+		c.assertHttpGet(req, issuer+configSuffix, nil, errors.New("Read configuration error"))
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(nil, issuer)
+	_, e := configurationProvider.getConfiguration(req, issuer)
 
 	if e == nil {
 		t.Error("An error was expected but not returned")
@@ -37,14 +39,15 @@ func Test_getConfiguration_UsesCorrectUrl(t *testing.T) {
 func Test_getConfiguration_WhenGetReturnsError(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{getConfig: c.httpGet}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	readError := errors.New("Read configuration error")
 	go func() {
-		c.assertHttpGet(anything, nil, readError)
+		c.assertHttpGet(req, anything, nil, readError)
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(nil, "issuer")
+	_, e := configurationProvider.getConfiguration(req, "issuer")
 
 	expectValidationError(t, e, ValidationErrorGetOpenIdConfigurationFailure, http.StatusUnauthorized, readError)
 
@@ -54,17 +57,18 @@ func Test_getConfiguration_WhenGetReturnsError(t *testing.T) {
 func Test_getConfiguration_WhenGetSucceeds(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{c.httpGet, c.decodeResponse}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	respBody := "openid configuration"
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(anything, resp, nil)
+		c.assertHttpGet(req, anything, resp, nil)
 		c.assertDecodeResponse(respBody, nil, nil)
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(nil, anything)
+	_, e := configurationProvider.getConfiguration(req, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)
@@ -76,17 +80,18 @@ func Test_getConfiguration_WhenGetSucceeds(t *testing.T) {
 func Test_getConfiguration_WhenDecodeResponseReturnsError(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{c.httpGet, c.decodeResponse}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	decodeError := errors.New("Decode configuration error")
 	respBody := "openid configuration"
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(anything, resp, nil)
+		c.assertHttpGet(req, anything, resp, nil)
 		c.assertDecodeResponse(anything, nil, decodeError)
 		c.close()
 	}()
 
-	_, e := configurationProvider.getConfiguration(nil, anything)
+	_, e := configurationProvider.getConfiguration(req, anything)
 
 	expectValidationError(t, e, ValidationErrorDecodeOpenIdConfigurationFailure, http.StatusUnauthorized, decodeError)
 
@@ -96,17 +101,18 @@ func Test_getConfiguration_WhenDecodeResponseReturnsError(t *testing.T) {
 func Test_getConfiguration_WhenDecodeResponseSucceeds(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	configurationProvider := httpConfigurationProvider{c.httpGet, c.decodeResponse}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	config := &configuration{"testissuer", "https://testissuer/jwk"}
 	respBody := "openid configuration"
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(anything, resp, nil)
+		c.assertHttpGet(req, anything, resp, nil)
 		c.assertDecodeResponse(anything, config, nil)
 		c.close()
 	}()
 
-	rc, e := configurationProvider.getConfiguration(nil, anything)
+	rc, e := configurationProvider.getConfiguration(req, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)

--- a/openid/doc.go
+++ b/openid/doc.go
@@ -19,11 +19,13 @@ of them you will need an instance of the Configuration type, to create that you 
 
        func ErrorHandler(eh ErrorHandlerFunc) func(*Configuration) error
        func ProvidersGetter(pg GetProvidersFunc) func(*Configuration) error
+       func HTTPGetter(hg HTTPGetFunc) func(*Configuration) error
 
        // extension points:
 
        type ErrorHandlerFunc func(error, http.ResponseWriter, *http.Request) bool
        type GetProvidersFunc func() ([]Provider, error)
+       type HTTPGetFunc func(r *http.Request, url string) (*http.Response, error)
 
 The Example below demonstrates these elements working together.
 

--- a/openid/errors.go
+++ b/openid/errors.go
@@ -89,8 +89,8 @@ func (ve ValidationError) Error() string {
 	return fmt.Sprintf("Validation error. %v", ve.Message)
 }
 
-// jwtErrorToOpenIdError converts errors of the type *jwt.ValidationError returned during token validation into errors of type *ValidationError
-func jwtErrorToOpenIdError(e error) *ValidationError {
+// jwtErrorToOpenIDError converts errors of the type *jwt.ValidationError returned during token validation into errors of type *ValidationError
+func jwtErrorToOpenIDError(e error) *ValidationError {
 	if jwtError, ok := e.(*jwt.ValidationError); ok {
 		if (jwtError.Errors & (jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired | jwt.ValidationErrorSignatureInvalid)) != 0 {
 			return &ValidationError{

--- a/openid/errors.go
+++ b/openid/errors.go
@@ -93,21 +93,37 @@ func (ve ValidationError) Error() string {
 func jwtErrorToOpenIdError(e error) *ValidationError {
 	if jwtError, ok := e.(*jwt.ValidationError); ok {
 		if (jwtError.Errors & (jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired | jwt.ValidationErrorSignatureInvalid)) != 0 {
-			return &ValidationError{Code: ValidationErrorJwtValidationFailure, Message: "Jwt token validation failed.", HTTPStatus: http.StatusUnauthorized}
+			return &ValidationError{
+				Code:       ValidationErrorJwtValidationFailure,
+				Message:    "Jwt token validation failed.",
+				HTTPStatus: http.StatusUnauthorized,
+			}
 		}
 
 		if (jwtError.Errors & jwt.ValidationErrorMalformed) != 0 {
-			return &ValidationError{Code: ValidationErrorJwtValidationFailure, Message: "Jwt token validation failed.", HTTPStatus: http.StatusBadRequest}
+			return &ValidationError{
+				Code:       ValidationErrorJwtValidationFailure,
+				Message:    "Jwt token validation failed.",
+				HTTPStatus: http.StatusBadRequest,
+			}
 		}
 
 		if (jwtError.Errors & jwt.ValidationErrorUnverifiable) != 0 {
 			// TODO: improve this once https://github.com/dgrijalva/jwt-go/issues/108 is resolved.
 			// Currently jwt.Parse does not surface errors returned by the KeyFunc.
-			return &ValidationError{Code: ValidationErrorJwtValidationFailure, Message: jwtError.Error(), HTTPStatus: http.StatusUnauthorized}
+			return &ValidationError{
+				Code:       ValidationErrorJwtValidationFailure,
+				Message:    jwtError.Error(),
+				HTTPStatus: http.StatusUnauthorized,
+			}
 		}
 	}
 
-	return &ValidationError{Code: ValidationErrorJwtValidationUnknownFailure, Message: "Jwt token validation failed with unknown error.", HTTPStatus: http.StatusInternalServerError}
+	return &ValidationError{
+		Code:       ValidationErrorJwtValidationUnknownFailure,
+		Message:    "Jwt token validation failed with unknown error.",
+		HTTPStatus: http.StatusInternalServerError,
+	}
 }
 
 func validationErrorToHTTPStatus(e error, rw http.ResponseWriter, req *http.Request) (halt bool) {

--- a/openid/httpclientmock_test.go
+++ b/openid/httpclientmock_test.go
@@ -49,7 +49,7 @@ func (c *HTTPClientMock) httpGet(req *http.Request, url string) (*http.Response,
 
 func (c *HTTPClientMock) assertHTTPGet(req *http.Request, url string, resp *http.Response, err error) {
 	call := (<-c.Calls).(*httpGetCall)
-	if req == nil || call.req != req {
+	if call.req != req {
 		c.t.Error("Expected getSigningKey with req", req, "but was", call.req)
 	}
 	if url != anything && call.url != url {

--- a/openid/httpclientmock_test.go
+++ b/openid/httpclientmock_test.go
@@ -47,7 +47,7 @@ func (c *HTTPClientMock) httpGet(req *http.Request, url string) (*http.Response,
 	return gr.resp, gr.err
 }
 
-func (c *HTTPClientMock) assertHttpGet(req *http.Request, url string, resp *http.Response, err error) {
+func (c *HTTPClientMock) assertHTTPGet(req *http.Request, url string, resp *http.Response, err error) {
 	call := (<-c.Calls).(*httpGetCall)
 	if req == nil || call.req != req {
 		c.t.Error("Expected getSigningKey with req", req, "but was", call.req)
@@ -65,7 +65,7 @@ func (c *HTTPClientMock) decodeResponse(reader io.Reader, value interface{}) err
 	case *configuration:
 		if dr.value != nil {
 			v.Issuer = dr.value.(*configuration).Issuer
-			v.JwksUri = dr.value.(*configuration).JwksUri
+			v.JwksURI = dr.value.(*configuration).JwksURI
 		}
 	case *jose.JsonWebKeySet:
 		if dr.value != nil {

--- a/openid/httpclientmock_test.go
+++ b/openid/httpclientmock_test.go
@@ -23,6 +23,7 @@ func NewHTTPClientMock(t *testing.T) *HTTPClientMock {
 }
 
 type httpGetCall struct {
+	req *http.Request
 	url string
 }
 
@@ -40,14 +41,17 @@ type decodeResponseResp struct {
 	err   error
 }
 
-func (c *HTTPClientMock) httpGet(r *http.Request, url string) (*http.Response, error) {
-	c.Calls <- &httpGetCall{url}
+func (c *HTTPClientMock) httpGet(req *http.Request, url string) (*http.Response, error) {
+	c.Calls <- &httpGetCall{req, url}
 	gr := (<-c.Calls).(*httpGetResp)
 	return gr.resp, gr.err
 }
 
-func (c *HTTPClientMock) assertHttpGet(url string, resp *http.Response, err error) {
+func (c *HTTPClientMock) assertHttpGet(req *http.Request, url string, resp *http.Response, err error) {
 	call := (<-c.Calls).(*httpGetCall)
+	if req == nil || call.req != req {
+		c.t.Error("Expected getSigningKey with req", req, "but was", call.req)
+	}
 	if url != anything && call.url != url {
 		c.t.Error("Expected httpGet with", url, "but was", call.url)
 	}

--- a/openid/httpclientmock_test.go
+++ b/openid/httpclientmock_test.go
@@ -40,7 +40,7 @@ type decodeResponseResp struct {
 	err   error
 }
 
-func (c *HTTPClientMock) httpGet(url string) (*http.Response, error) {
+func (c *HTTPClientMock) httpGet(r *http.Request, url string) (*http.Response, error) {
 	c.Calls <- &httpGetCall{url}
 	gr := (<-c.Calls).(*httpGetResp)
 	return gr.resp, gr.err

--- a/openid/idtokenvalidator.go
+++ b/openid/idtokenvalidator.go
@@ -64,8 +64,16 @@ func (tv *idTokenValidator) renewAndGetSigningKey(r *http.Request, jt *jwt.Token
 	if err != nil {
 		return nil, err
 	}
+	kid, ok := jt.Header[keyIDJwtHeaderName].(string)
+	if !ok {
+		return nil, &ValidationError{
+			Code:       ValidationErrorKidNotFound,
+			Message:    "The token 'kid' header was not found or was empty.",
+			HTTPStatus: http.StatusUnauthorized,
+		}
+	}
 	var key []byte
-	if key, err = tv.keyGetter.getSigningKey(r, iss, jt.Header[keyIDJwtHeaderName].(string)); err == nil {
+	if key, err = tv.keyGetter.getSigningKey(r, iss, kid); err == nil {
 		return tv.rsaParser(key)
 	}
 

--- a/openid/idtokenvalidator.go
+++ b/openid/idtokenvalidator.go
@@ -49,7 +49,7 @@ func (tv *idTokenValidator) validate(r *http.Request, t string) (*jwt.Token, err
 	}
 
 	if err != nil {
-		return nil, jwtErrorToOpenIdError(err)
+		return nil, jwtErrorToOpenIDError(err)
 	}
 
 	return jt, nil
@@ -125,11 +125,19 @@ func validateIssuer(jt *jwt.Token, ps []Provider) (*Provider, error) {
 	if iss, ok := issuerClaim.(string); ok {
 		ti = iss
 	} else {
-		return nil, &ValidationError{Code: ValidationErrorInvalidIssuerType, Message: fmt.Sprintf("Invalid Issuer type: %T", issuerClaim), HTTPStatus: http.StatusUnauthorized}
+		return nil, &ValidationError{
+			Code:       ValidationErrorInvalidIssuerType,
+			Message:    fmt.Sprintf("Invalid Issuer type: %T", issuerClaim),
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	if ti == "" {
-		return nil, &ValidationError{Code: ValidationErrorInvalidIssuer, Message: "The token 'iss' claim was not found or was empty.", HTTPStatus: http.StatusUnauthorized}
+		return nil, &ValidationError{
+			Code:       ValidationErrorInvalidIssuer,
+			Message:    "The token 'iss' claim was not found or was empty.",
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	// Workaround for tokens issued by google
@@ -144,7 +152,11 @@ func validateIssuer(jt *jwt.Token, ps []Provider) (*Provider, error) {
 		}
 	}
 
-	return nil, &ValidationError{Code: ValidationErrorIssuerNotFound, Message: fmt.Sprintf("No provider was registered with issuer: %v", ti), HTTPStatus: http.StatusUnauthorized}
+	return nil, &ValidationError{
+		Code:       ValidationErrorIssuerNotFound,
+		Message:    fmt.Sprintf("No provider was registered with issuer: %v", ti),
+		HTTPStatus: http.StatusUnauthorized,
+	}
 }
 
 func validateSubject(jt *jwt.Token) (string, error) {
@@ -154,11 +166,19 @@ func validateSubject(jt *jwt.Token) (string, error) {
 	if sub, ok := subjectClaim.(string); ok {
 		ts = sub
 	} else {
-		return ts, &ValidationError{Code: ValidationErrorInvalidSubjectType, Message: fmt.Sprintf("Invalid subject type: %T", subjectClaim), HTTPStatus: http.StatusUnauthorized}
+		return ts, &ValidationError{
+			Code:       ValidationErrorInvalidSubjectType,
+			Message:    fmt.Sprintf("Invalid subject type: %T", subjectClaim),
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	if ts == "" {
-		return ts, &ValidationError{Code: ValidationErrorInvalidSubject, Message: "The token 'sub' claim was not found or was empty.", HTTPStatus: http.StatusUnauthorized}
+		return ts, &ValidationError{
+			Code:       ValidationErrorInvalidSubject,
+			Message:    "The token 'sub' claim was not found or was empty.",
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	return ts, nil
@@ -176,11 +196,19 @@ func validateAudiences(jt *jwt.Token, p *Provider) (string, error) {
 			ta, ok := audienceClaim.(string)
 			if !ok {
 				fmt.Printf("aud type %T \n", audienceClaim)
-				return "", &ValidationError{Code: ValidationErrorInvalidAudienceType, Message: fmt.Sprintf("Invalid Audiences type: %T", audiencesClaim), HTTPStatus: http.StatusUnauthorized}
+				return "", &ValidationError{
+					Code:       ValidationErrorInvalidAudienceType,
+					Message:    fmt.Sprintf("Invalid Audiences type: %T", audiencesClaim),
+					HTTPStatus: http.StatusUnauthorized,
+				}
 			}
 
 			if ta == "" {
-				return "", &ValidationError{Code: ValidationErrorInvalidAudience, Message: "The token 'aud' claim was not found or was empty.", HTTPStatus: http.StatusUnauthorized}
+				return "", &ValidationError{
+					Code:       ValidationErrorInvalidAudience,
+					Message:    "The token 'aud' claim was not found or was empty.",
+					HTTPStatus: http.StatusUnauthorized,
+				}
 			}
 
 			if ta == aud {
@@ -189,7 +217,11 @@ func validateAudiences(jt *jwt.Token, p *Provider) (string, error) {
 		}
 	}
 
-	return "", &ValidationError{Code: ValidationErrorAudienceNotFound, Message: fmt.Sprintf("The provider %v does not have a client id matching any of the token audiences %+v", p.Issuer, audiencesClaim), HTTPStatus: http.StatusUnauthorized}
+	return "", &ValidationError{
+		Code:       ValidationErrorAudienceNotFound,
+		Message:    fmt.Sprintf("The provider %v does not have a client id matching any of the token audiences %+v", p.Issuer, audiencesClaim),
+		HTTPStatus: http.StatusUnauthorized,
+	}
 }
 
 func getAudiences(t *jwt.Token) ([]interface{}, error) {
@@ -200,7 +232,11 @@ func getAudiences(t *jwt.Token) ([]interface{}, error) {
 		return audiencesClaim.([]interface{}), nil
 	}
 
-	return nil, &ValidationError{Code: ValidationErrorInvalidAudienceType, Message: fmt.Sprintf("Invalid Audiences type: %T", audiencesClaim), HTTPStatus: http.StatusUnauthorized}
+	return nil, &ValidationError{
+		Code:       ValidationErrorInvalidAudienceType,
+		Message:    fmt.Sprintf("Invalid Audiences type: %T", audiencesClaim),
+		HTTPStatus: http.StatusUnauthorized,
+	}
 
 }
 

--- a/openid/idtokenvalidator_test.go
+++ b/openid/idtokenvalidator_test.go
@@ -19,7 +19,7 @@ func Test_getSigningKey_WhenGetProvidersReturnsError(t *testing.T) {
 		pm.close()
 	}()
 
-	sk, err := tv.getSigningKey(nil)
+	sk, err := tv.getSigningKey(nil, nil)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -45,10 +45,10 @@ func Test_getSigningKey_WhenGetProvidersReturnsEmptyCollection(t *testing.T) {
 		pm.close()
 	}()
 
-	_, err := tv.getSigningKey(nil)
+	_, err := tv.getSigningKey(nil, nil)
 	expectSetupError(t, err, SetupErrorEmptyProviderCollection)
 
-	_, err = tv.getSigningKey(nil)
+	_, err = tv.getSigningKey(nil, nil)
 	expectSetupError(t, err, SetupErrorEmptyProviderCollection)
 
 	pm.assertDone()
@@ -65,7 +65,7 @@ func Test_getSigningKey_UsingTokenWithInvalidIssuerType(t *testing.T) {
 
 	jt := jwt.New(jwt.SigningMethodRS256)
 	jt.Claims.(jwt.MapClaims)["iss"] = 0 // The expected issuer type is string, not int.
-	sk, err := tv.getSigningKey(jt)
+	sk, err := tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -88,7 +88,7 @@ func Test_getSigningKey_UsingTokenWithEmptyIssuer(t *testing.T) {
 	jt := jwt.New(jwt.SigningMethodRS256)
 
 	// The token has no 'iss' claim
-	sk, err := tv.getSigningKey(jt)
+	sk, err := tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -98,7 +98,7 @@ func Test_getSigningKey_UsingTokenWithEmptyIssuer(t *testing.T) {
 
 	// The token has '' as 'iss' claim
 	jt.Claims.(jwt.MapClaims)["iss"] = ""
-	sk, err = tv.getSigningKey(jt)
+	sk, err = tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -121,7 +121,7 @@ func Test_getSigningKey_UsingTokenWithUnknownIssuer(t *testing.T) {
 	jt.Claims.(jwt.MapClaims)["iss"] = "http://unknown"
 
 	// The token has no 'iss' claim
-	sk, err := tv.getSigningKey(jt)
+	sk, err := tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -143,7 +143,7 @@ func Test_getSigningKey_UsingTokenWithInvalidAudienceType(t *testing.T) {
 	jt.Claims.(jwt.MapClaims)["iss"] = "https://issuer"
 	jt.Claims.(jwt.MapClaims)["aud"] = 0 // Expected 'aud' type is string
 
-	sk, err := tv.getSigningKey(jt)
+	sk, err := tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -166,7 +166,7 @@ func Test_getSigningKey_UsingTokenWithInvalidAudience(t *testing.T) {
 	jt.Claims.(jwt.MapClaims)["iss"] = "https://issuer"
 
 	// No audience claim
-	sk, err := tv.getSigningKey(jt)
+	sk, err := tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -176,7 +176,7 @@ func Test_getSigningKey_UsingTokenWithInvalidAudience(t *testing.T) {
 
 	// Empty audience claim.
 	jt.Claims.(jwt.MapClaims)["aud"] = ""
-	sk, err = tv.getSigningKey(jt)
+	sk, err = tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -199,7 +199,7 @@ func Test_getSigningKey_UsingTokenWithUnknownAudience(t *testing.T) {
 	jt.Claims.(jwt.MapClaims)["iss"] = "https://issuer"
 	jt.Claims.(jwt.MapClaims)["aud"] = "client3" // unknown audience
 
-	sk, err := tv.getSigningKey(jt)
+	sk, err := tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -221,7 +221,7 @@ func Test_getSigningKey_UsingTokenWithUnknownMultipleAudiences(t *testing.T) {
 	jt.Claims.(jwt.MapClaims)["iss"] = "https://issuer"
 	jt.Claims.(jwt.MapClaims)["aud"] = []interface{}{"client3", "client4"} // unknown audiences
 
-	sk, err := tv.getSigningKey(jt)
+	sk, err := tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -243,7 +243,7 @@ func Test_getSigningKey_UsingTokenWithInvalidSubjectType(t *testing.T) {
 	jt.Claims.(jwt.MapClaims)["iss"] = "https://issuer"
 	jt.Claims.(jwt.MapClaims)["aud"] = "client"
 	jt.Claims.(jwt.MapClaims)["sub"] = 0 // The expected 'sub' claim type is string
-	sk, err := tv.getSigningKey(jt)
+	sk, err := tv.getSigningKey(nil, jt)
 
 	if sk != nil {
 		t.Error("The returned signing key should be nil.")
@@ -273,7 +273,7 @@ func Test_getSigningKey_UsingValidToken_WhenSigningKeyGetterReturnsError(t *test
 	jt.Claims.(jwt.MapClaims)["sub"] = "subject1"
 	jt.Header["kid"] = keyID
 
-	_, err := tv.getSigningKey(jt)
+	_, err := tv.getSigningKey(nil, jt)
 
 	expectValidationError(t, err, ee.Code, ee.HTTPStatus, nil)
 	pm.assertDone()
@@ -303,7 +303,7 @@ func Test_getSigningKey_UsingValidToken_WhenSigningKeyGetterSucceeds(t *testing.
 	jt.Claims.(jwt.MapClaims)["sub"] = "subject1"
 	jt.Header["kid"] = keyID
 
-	rsk, err := tv.getSigningKey(jt)
+	rsk, err := tv.getSigningKey(nil, jt)
 
 	if err != nil {
 		t.Error("An error was returned but not expected.", err)
@@ -337,7 +337,7 @@ func Test_getSigningKey_UsingValidToken_WithoutKeyIdentifier_WhenSigningKeyGette
 	jt.Claims.(jwt.MapClaims)["aud"] = "client"
 	jt.Claims.(jwt.MapClaims)["sub"] = "subject1"
 
-	rsk, err := tv.getSigningKey(jt)
+	rsk, err := tv.getSigningKey(nil, jt)
 
 	if err != nil {
 		t.Error("An error was returned but not expected.", err)
@@ -372,7 +372,7 @@ func Test_getSigningKey_UsingValidTokenWithMultipleAudiences(t *testing.T) {
 	jt.Claims.(jwt.MapClaims)["sub"] = "subject1"
 	jt.Header["kid"] = keyID
 
-	rsk, err := tv.getSigningKey(jt)
+	rsk, err := tv.getSigningKey(nil, jt)
 
 	if err != nil {
 		t.Error("An error was returned but not expected.", err)
@@ -396,7 +396,7 @@ func Test_renewAndGetSigningKey_UsingValidToken_WhenFlushCachedSigningKeysReturn
 	jt := jwt.New(jwt.SigningMethodRS256)
 	jt.Claims.(jwt.MapClaims)["iss"] = ""
 
-	_, err := tv.renewAndGetSigningKey(jt)
+	_, err := tv.renewAndGetSigningKey(nil, jt)
 
 	expectValidationError(t, err, ee.Code, ee.HTTPStatus, nil)
 
@@ -417,7 +417,7 @@ func Test_renewAndGetSigningKey_UsingValidToken_WhenGetSigningKeyReturnsError(t 
 	jt.Claims.(jwt.MapClaims)["iss"] = ""
 	jt.Header["kid"] = ""
 
-	_, err := tv.renewAndGetSigningKey(jt)
+	_, err := tv.renewAndGetSigningKey(nil, jt)
 
 	expectValidationError(t, err, ee.Code, ee.HTTPStatus, nil)
 
@@ -441,7 +441,7 @@ func Test_renewAndGetSigningKey_UsingValidToken_WhenGetSigningKeySucceeds(t *tes
 	jt.Claims.(jwt.MapClaims)["iss"] = ""
 	jt.Header["kid"] = ""
 
-	rsk, err := tv.renewAndGetSigningKey(jt)
+	rsk, err := tv.renewAndGetSigningKey(nil, jt)
 
 	if err != nil {
 		t.Error("An error was returned but not expected.", err)
@@ -463,7 +463,7 @@ func Test_validate_WhenParserReturnsErrorFirstTime(t *testing.T) {
 		jm.close()
 	}()
 
-	_, err := tv.validate(anything)
+	_, err := tv.validate(nil, anything)
 
 	expectValidationError(t, err, ee.Code, ee.HTTPStatus, ee.Err)
 
@@ -480,7 +480,7 @@ func Test_validate_WhenParserSuceedsFirstTime(t *testing.T) {
 		jm.close()
 	}()
 
-	rjt, err := tv.validate(anything)
+	rjt, err := tv.validate(nil, anything)
 
 	if err != nil {
 		t.Error("Unexpected error was returned.", err)
@@ -506,7 +506,7 @@ func Test_validate_WhenParserReturnsErrorSecondTime(t *testing.T) {
 		jm.close()
 	}()
 
-	_, err := tv.validate(anything)
+	_, err := tv.validate(nil, anything)
 
 	expectValidationError(t, err, ee.Code, ee.HTTPStatus, ee.Err)
 
@@ -525,7 +525,7 @@ func Test_validate_WhenParserReturnsSignatureInvalidErrorSecondTime(t *testing.T
 		jm.close()
 	}()
 
-	_, err := tv.validate(anything)
+	_, err := tv.validate(nil, anything)
 
 	expectValidationError(t, err, ee.Code, ee.HTTPStatus, ee.Err)
 
@@ -545,7 +545,7 @@ func Test_validate_WhenParserSuceedsSecondTime(t *testing.T) {
 		jm.close()
 	}()
 
-	rjt, err := tv.validate(anything)
+	rjt, err := tv.validate(nil, anything)
 
 	if err != nil {
 		t.Error("Unexpected error was returned.", err)

--- a/openid/idtokenvalidator_test.go
+++ b/openid/idtokenvalidator_test.go
@@ -321,7 +321,6 @@ func Test_getSigningKey_UsingValidToken_WhenSigningKeyGetterSucceeds(t *testing.
 func Test_getSigningKey_UsingValidToken_WithoutKeyIdentifier_WhenSigningKeyGetterSucceeds(t *testing.T) {
 	pm, _, sm, kp, tv := createIDTokenValidator(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	iss := "https://issuer"
 	keyID := ""
 	esk := "signingKey"
@@ -329,7 +328,7 @@ func Test_getSigningKey_UsingValidToken_WithoutKeyIdentifier_WhenSigningKeyGette
 
 	go func() {
 		pm.assertGetProviders([]Provider{{Issuer: iss, ClientIDs: []string{"client"}}}, nil)
-		sm.assertGetSigningKey(req, iss, keyID, []byte(esk), nil)
+		sm.assertGetSigningKey(nil, iss, keyID, []byte(esk), nil)
 		kp.assertParse([]byte(esk), pk, nil)
 		pm.close()
 		sm.close()
@@ -341,7 +340,7 @@ func Test_getSigningKey_UsingValidToken_WithoutKeyIdentifier_WhenSigningKeyGette
 	jt.Claims.(jwt.MapClaims)["aud"] = "client"
 	jt.Claims.(jwt.MapClaims)["sub"] = "subject1"
 
-	rsk, err := tv.getSigningKey(req, jt)
+	rsk, err := tv.getSigningKey(nil, jt)
 
 	if err != nil {
 		t.Error("An error was returned but not expected.", err)
@@ -356,7 +355,6 @@ func Test_getSigningKey_UsingValidToken_WithoutKeyIdentifier_WhenSigningKeyGette
 func Test_getSigningKey_UsingValidTokenWithMultipleAudiences(t *testing.T) {
 	pm, _, sm, kp, tv := createIDTokenValidator(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	iss := "https://issuer"
 	keyID := "kid"
 	esk := "signingKey"
@@ -364,7 +362,7 @@ func Test_getSigningKey_UsingValidTokenWithMultipleAudiences(t *testing.T) {
 
 	go func() {
 		pm.assertGetProviders([]Provider{{Issuer: iss, ClientIDs: []string{"client"}}}, nil)
-		sm.assertGetSigningKey(req, iss, keyID, []byte(esk), nil)
+		sm.assertGetSigningKey(nil, iss, keyID, []byte(esk), nil)
 		kp.assertParse([]byte(esk), pk, nil)
 		pm.close()
 		sm.close()
@@ -377,7 +375,7 @@ func Test_getSigningKey_UsingValidTokenWithMultipleAudiences(t *testing.T) {
 	jt.Claims.(jwt.MapClaims)["sub"] = "subject1"
 	jt.Header["kid"] = keyID
 
-	rsk, err := tv.getSigningKey(req, jt)
+	rsk, err := tv.getSigningKey(nil, jt)
 
 	if err != nil {
 		t.Error("An error was returned but not expected.", err)
@@ -411,12 +409,10 @@ func Test_renewAndGetSigningKey_UsingValidToken_WhenFlushCachedSigningKeysReturn
 func Test_renewAndGetSigningKey_UsingValidToken_WhenGetSigningKeyReturnsError(t *testing.T) {
 	_, _, sm, _, tv := createIDTokenValidator(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-
 	ee := &ValidationError{Code: ValidationErrorIssuerNotFound, HTTPStatus: http.StatusUnauthorized}
 	go func() {
 		sm.assertFlushCachedSigningKeys(anything, nil)
-		sm.assertGetSigningKey(req, anything, anything, nil, ee)
+		sm.assertGetSigningKey(nil, anything, anything, nil, ee)
 		sm.close()
 	}()
 
@@ -424,7 +420,7 @@ func Test_renewAndGetSigningKey_UsingValidToken_WhenGetSigningKeyReturnsError(t 
 	jt.Claims.(jwt.MapClaims)["iss"] = ""
 	jt.Header["kid"] = ""
 
-	_, err := tv.renewAndGetSigningKey(req, jt)
+	_, err := tv.renewAndGetSigningKey(nil, jt)
 
 	expectValidationError(t, err, ee.Code, ee.HTTPStatus, nil)
 
@@ -433,13 +429,12 @@ func Test_renewAndGetSigningKey_UsingValidToken_WhenGetSigningKeyReturnsError(t 
 
 func Test_renewAndGetSigningKey_UsingValidToken_WhenGetSigningKeySucceeds(t *testing.T) {
 	_, _, sm, kp, tv := createIDTokenValidator(t)
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	esk := "signingKey"
 	pk := &rsa.PublicKey{N: nil, E: 365}
 
 	go func() {
 		sm.assertFlushCachedSigningKeys(anything, nil)
-		sm.assertGetSigningKey(req, anything, anything, []byte(esk), nil)
+		sm.assertGetSigningKey(nil, anything, anything, []byte(esk), nil)
 		kp.assertParse([]byte(esk), pk, nil)
 		sm.close()
 		kp.close()
@@ -449,7 +444,7 @@ func Test_renewAndGetSigningKey_UsingValidToken_WhenGetSigningKeySucceeds(t *tes
 	jt.Claims.(jwt.MapClaims)["iss"] = ""
 	jt.Header["kid"] = ""
 
-	rsk, err := tv.renewAndGetSigningKey(req, jt)
+	rsk, err := tv.renewAndGetSigningKey(nil, jt)
 
 	if err != nil {
 		t.Error("An error was returned but not expected.", err)

--- a/openid/idtokenvalidator_test.go
+++ b/openid/idtokenvalidator_test.go
@@ -13,7 +13,7 @@ import (
 func Test_getSigningKey_WhenGetProvidersReturnsError(t *testing.T) {
 	pm, _, _, _, tv := createIDTokenValidator(t)
 
-	ee := errors.New("Error getting providers.")
+	ee := errors.New("Error getting providers")
 
 	go func() {
 		pm.assertGetProviders(nil, ee)

--- a/openid/jwksgettermock_test.go
+++ b/openid/jwksgettermock_test.go
@@ -34,7 +34,7 @@ func (c *jwksGetterMock) getJwkSet(r *http.Request, url string) (jose.JsonWebKey
 
 func (c *jwksGetterMock) assertGetJwks(req *http.Request, url string, jwks jose.JsonWebKeySet, err error) {
 	call := (<-c.Calls).(*getJwksCall)
-	if req == nil || call.req != req {
+	if call.req != req {
 		c.t.Error("Expected getSigningKey with req", req, "but was", call.req)
 	}
 	if url != anything && call.url != url {

--- a/openid/jwksgettermock_test.go
+++ b/openid/jwksgettermock_test.go
@@ -1,6 +1,7 @@
 package openid
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/square/go-jose"
@@ -24,7 +25,7 @@ type getJwksResponse struct {
 	err  error
 }
 
-func (c *jwksGetterMock) getJwkSet(url string) (jose.JsonWebKeySet, error) {
+func (c *jwksGetterMock) getJwkSet(r *http.Request, url string) (jose.JsonWebKeySet, error) {
 	c.Calls <- &getJwksCall{url}
 	gr := (<-c.Calls).(*getJwksResponse)
 	return gr.jwks, gr.err

--- a/openid/jwksgettermock_test.go
+++ b/openid/jwksgettermock_test.go
@@ -17,6 +17,7 @@ func newJwksGetterMock(t *testing.T) *jwksGetterMock {
 }
 
 type getJwksCall struct {
+	req *http.Request
 	url string
 }
 
@@ -26,13 +27,16 @@ type getJwksResponse struct {
 }
 
 func (c *jwksGetterMock) getJwkSet(r *http.Request, url string) (jose.JsonWebKeySet, error) {
-	c.Calls <- &getJwksCall{url}
+	c.Calls <- &getJwksCall{r, url}
 	gr := (<-c.Calls).(*getJwksResponse)
 	return gr.jwks, gr.err
 }
 
-func (c *jwksGetterMock) assertGetJwks(url string, jwks jose.JsonWebKeySet, err error) {
+func (c *jwksGetterMock) assertGetJwks(req *http.Request, url string, jwks jose.JsonWebKeySet, err error) {
 	call := (<-c.Calls).(*getJwksCall)
+	if req == nil || call.req != req {
+		c.t.Error("Expected getSigningKey with req", req, "but was", call.req)
+	}
 	if url != anything && call.url != url {
 		c.t.Error("Expected getJwks with", url, "but was", call.url)
 	}

--- a/openid/jwksprovider.go
+++ b/openid/jwksprovider.go
@@ -26,13 +26,23 @@ func (httpProv *httpJwksProvider) getJwkSet(r *http.Request, url string) (jose.J
 	resp, err := httpProv.getJwks(r, url)
 
 	if err != nil {
-		return jwks, &ValidationError{Code: ValidationErrorGetJwksFailure, Message: fmt.Sprintf("Failure while contacting the jwk endpoint %v.", url), Err: err, HTTPStatus: http.StatusUnauthorized}
+		return jwks, &ValidationError{
+			Code:       ValidationErrorGetJwksFailure,
+			Message:    fmt.Sprintf("Failure while contacting the jwk endpoint %v.", url),
+			Err:        err,
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	defer resp.Body.Close()
 
 	if err := httpProv.decodeJwks(resp.Body, &jwks); err != nil {
-		return jwks, &ValidationError{Code: ValidationErrorDecodeJwksFailure, Message: fmt.Sprintf("Failure while decoding the jwk retrieved from the  endpoint %v.", url), Err: err, HTTPStatus: http.StatusUnauthorized}
+		return jwks, &ValidationError{
+			Code:       ValidationErrorDecodeJwksFailure,
+			Message:    fmt.Sprintf("Failure while decoding the jwk retrieved from the  endpoint %v.", url),
+			Err:        err,
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	return jwks, nil

--- a/openid/jwksprovider.go
+++ b/openid/jwksprovider.go
@@ -8,7 +8,7 @@ import (
 )
 
 type jwksGetter interface {
-	getJwkSet(string) (jose.JsonWebKeySet, error)
+	getJwkSet(r *http.Request, url string) (jose.JsonWebKeySet, error)
 }
 
 type httpJwksProvider struct {
@@ -20,10 +20,10 @@ func newHTTPJwksProvider(gf httpGetFunc, df decodeResponseFunc) *httpJwksProvide
 	return &httpJwksProvider{gf, df}
 }
 
-func (httpProv *httpJwksProvider) getJwkSet(url string) (jose.JsonWebKeySet, error) {
+func (httpProv *httpJwksProvider) getJwkSet(r *http.Request, url string) (jose.JsonWebKeySet, error) {
 
 	var jwks jose.JsonWebKeySet
-	resp, err := httpProv.getJwks(url)
+	resp, err := httpProv.getJwks(r, url)
 
 	if err != nil {
 		return jwks, &ValidationError{Code: ValidationErrorGetJwksFailure, Message: fmt.Sprintf("Failure while contacting the jwk endpoint %v.", url), Err: err, HTTPStatus: http.StatusUnauthorized}

--- a/openid/jwksprovider.go
+++ b/openid/jwksprovider.go
@@ -12,11 +12,11 @@ type jwksGetter interface {
 }
 
 type httpJwksProvider struct {
-	getJwks    httpGetFunc
+	getJwks    HTTPGetFunc
 	decodeJwks decodeResponseFunc
 }
 
-func newHTTPJwksProvider(gf httpGetFunc, df decodeResponseFunc) *httpJwksProvider {
+func newHTTPJwksProvider(gf HTTPGetFunc, df decodeResponseFunc) *httpJwksProvider {
 	return &httpJwksProvider{gf, df}
 }
 

--- a/openid/jwksprovider_test.go
+++ b/openid/jwksprovider_test.go
@@ -20,7 +20,7 @@ func Test_getJwkSet_UsesCorrectUrl(t *testing.T) {
 		c.close()
 	}()
 
-	_, e := jwksProvider.getJwkSet(url)
+	_, e := jwksProvider.getJwkSet(nil, url)
 
 	if e == nil {
 		t.Error("An error was expected but not returned")
@@ -39,7 +39,7 @@ func Test_getJwkSet_WhenGetReturnsError(t *testing.T) {
 		c.close()
 	}()
 
-	_, e := jwksProvider.getJwkSet(anything)
+	_, e := jwksProvider.getJwkSet(nil, anything)
 
 	expectValidationError(t, e, ValidationErrorGetJwksFailure, http.StatusUnauthorized, readError)
 
@@ -59,7 +59,7 @@ func Test_getJwkSet_WhenGetSucceeds(t *testing.T) {
 		c.close()
 	}()
 
-	_, e := jwksProvider.getJwkSet(anything)
+	_, e := jwksProvider.getJwkSet(nil, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)
@@ -81,7 +81,7 @@ func Test_getJwkSet_WhenDecodeResponseReturnsError(t *testing.T) {
 		c.close()
 	}()
 
-	_, e := jwksProvider.getJwkSet(anything)
+	_, e := jwksProvider.getJwkSet(nil, anything)
 
 	expectValidationError(t, e, ValidationErrorDecodeJwksFailure, http.StatusUnauthorized, decodeError)
 
@@ -105,7 +105,7 @@ func Test_getJwkSet_WhenDecodeResponseSucceeds(t *testing.T) {
 		c.close()
 	}()
 
-	rj, e := jwksProvider.getJwkSet(anything)
+	rj, e := jwksProvider.getJwkSet(nil, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)

--- a/openid/jwksprovider_test.go
+++ b/openid/jwksprovider_test.go
@@ -18,7 +18,7 @@ func Test_getJwkSet_UsesCorrectUrl(t *testing.T) {
 	url := "https://jwks"
 
 	go func() {
-		c.assertHttpGet(req, url, nil, errors.New("Read configuration error"))
+		c.assertHTTPGet(req, url, nil, errors.New("Read configuration error"))
 		c.close()
 	}()
 
@@ -38,7 +38,7 @@ func Test_getJwkSet_WhenGetReturnsError(t *testing.T) {
 
 	readError := errors.New("Read jwks error")
 	go func() {
-		c.assertHttpGet(req, anything, nil, readError)
+		c.assertHTTPGet(req, anything, nil, readError)
 		c.close()
 	}()
 
@@ -58,7 +58,7 @@ func Test_getJwkSet_WhenGetSucceeds(t *testing.T) {
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(req, anything, resp, nil)
+		c.assertHTTPGet(req, anything, resp, nil)
 		c.assertDecodeResponse(respBody, nil, nil)
 		c.close()
 	}()
@@ -81,7 +81,7 @@ func Test_getJwkSet_WhenDecodeResponseReturnsError(t *testing.T) {
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(req, anything, resp, nil)
+		c.assertHTTPGet(req, anything, resp, nil)
 		c.assertDecodeResponse(anything, nil, decodeError)
 		c.close()
 	}()
@@ -106,7 +106,7 @@ func Test_getJwkSet_WhenDecodeResponseSucceeds(t *testing.T) {
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHttpGet(req, anything, resp, nil)
+		c.assertHTTPGet(req, anything, resp, nil)
 		c.assertDecodeResponse(anything, jwks, nil)
 		c.close()
 	}()

--- a/openid/jwksprovider_test.go
+++ b/openid/jwksprovider_test.go
@@ -34,15 +34,14 @@ func Test_getJwkSet_UsesCorrectUrl(t *testing.T) {
 func Test_getJwkSet_WhenGetReturnsError(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	jwksProvider := httpJwksProvider{getJwks: c.httpGet}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	readError := errors.New("Read jwks error")
 	go func() {
-		c.assertHTTPGet(req, anything, nil, readError)
+		c.assertHTTPGet(nil, anything, nil, readError)
 		c.close()
 	}()
 
-	_, e := jwksProvider.getJwkSet(req, anything)
+	_, e := jwksProvider.getJwkSet(nil, anything)
 
 	expectValidationError(t, e, ValidationErrorGetJwksFailure, http.StatusUnauthorized, readError)
 
@@ -52,18 +51,17 @@ func Test_getJwkSet_WhenGetReturnsError(t *testing.T) {
 func Test_getJwkSet_WhenGetSucceeds(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	jwksProvider := httpJwksProvider{c.httpGet, c.decodeResponse}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	respBody := "jwk set"
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHTTPGet(req, anything, resp, nil)
+		c.assertHTTPGet(nil, anything, resp, nil)
 		c.assertDecodeResponse(respBody, nil, nil)
 		c.close()
 	}()
 
-	_, e := jwksProvider.getJwkSet(req, anything)
+	_, e := jwksProvider.getJwkSet(nil, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)
@@ -75,18 +73,17 @@ func Test_getJwkSet_WhenGetSucceeds(t *testing.T) {
 func Test_getJwkSet_WhenDecodeResponseReturnsError(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	jwksProvider := httpJwksProvider{c.httpGet, c.decodeResponse}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	decodeError := errors.New("Decode jwks error")
 	respBody := "jwk set."
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHTTPGet(req, anything, resp, nil)
+		c.assertHTTPGet(nil, anything, resp, nil)
 		c.assertDecodeResponse(anything, nil, decodeError)
 		c.close()
 	}()
 
-	_, e := jwksProvider.getJwkSet(req, anything)
+	_, e := jwksProvider.getJwkSet(nil, anything)
 
 	expectValidationError(t, e, ValidationErrorDecodeJwksFailure, http.StatusUnauthorized, decodeError)
 
@@ -96,7 +93,6 @@ func Test_getJwkSet_WhenDecodeResponseReturnsError(t *testing.T) {
 func Test_getJwkSet_WhenDecodeResponseSucceeds(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	jwksProvider := httpJwksProvider{c.httpGet, c.decodeResponse}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	keys := []jose.JsonWebKey{
 		{Key: "key1", Certificates: nil, KeyID: "keyid1", Algorithm: "algo1", Use: "use1"},
 		{Key: "key2", Certificates: nil, KeyID: "keyid2", Algorithm: "algo2", Use: "use2"},
@@ -106,12 +102,12 @@ func Test_getJwkSet_WhenDecodeResponseSucceeds(t *testing.T) {
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 
 	go func() {
-		c.assertHTTPGet(req, anything, resp, nil)
+		c.assertHTTPGet(nil, anything, resp, nil)
 		c.assertDecodeResponse(anything, jwks, nil)
 		c.close()
 	}()
 
-	rj, e := jwksProvider.getJwkSet(req, anything)
+	rj, e := jwksProvider.getJwkSet(nil, anything)
 
 	if e != nil {
 		t.Error("An error was returned but not expected", e)

--- a/openid/jwttokenvalidatormock_test.go
+++ b/openid/jwttokenvalidatormock_test.go
@@ -17,7 +17,8 @@ func newJwtTokenValidatorMock(t *testing.T) *jwtTokenValidatorMock {
 }
 
 type validateCall struct {
-	t string
+	req *http.Request
+	t   string
 }
 
 type validateResp struct {
@@ -26,7 +27,7 @@ type validateResp struct {
 }
 
 func (j *jwtTokenValidatorMock) validate(r *http.Request, t string) (*jwt.Token, error) {
-	j.Calls <- &validateCall{t}
+	j.Calls <- &validateCall{r, t}
 	vr := (<-j.Calls).(*validateResp)
 	return vr.jt, vr.err
 }

--- a/openid/jwttokenvalidatormock_test.go
+++ b/openid/jwttokenvalidatormock_test.go
@@ -1,6 +1,7 @@
 package openid
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/dgrijalva/jwt-go"
@@ -24,7 +25,7 @@ type validateResp struct {
 	err error
 }
 
-func (j *jwtTokenValidatorMock) validate(t string) (*jwt.Token, error) {
+func (j *jwtTokenValidatorMock) validate(r *http.Request, t string) (*jwt.Token, error) {
 	j.Calls <- &validateCall{t}
 	vr := (<-j.Calls).(*validateResp)
 	return vr.jt, vr.err

--- a/openid/middleware_test.go
+++ b/openid/middleware_test.go
@@ -42,7 +42,7 @@ func Test_authenticateUser_WhenGetIDTokenReturnsError_WhenErrorHandlerHalts(t *t
 func Test_authenticateUser_WhenValidateReturnsError_WhenErrorHandlerHalts(t *testing.T) {
 	vm, c := createConfiguration(t, errorHandlerHalt, getIDTokenReturnsSuccess)
 	go func() {
-		vm.assertValidate(idToken, nil, errors.New("Error while validating the token."))
+		vm.assertValidate(idToken, nil, errors.New("Error while validating the token"))
 		vm.close()
 	}()
 
@@ -107,7 +107,7 @@ func createConfiguration(t *testing.T, eh ErrorHandlerFunc, gt GetIDTokenFunc) (
 }
 
 func getIDTokenReturnsError(r *http.Request) (string, error) {
-	return "", errors.New("An error happened when returning ID Token.")
+	return "", errors.New("An error happened when returning ID Token")
 }
 
 func getIDTokenReturnsSuccess(r *http.Request) (string, error) {

--- a/openid/provider.go
+++ b/openid/provider.go
@@ -37,7 +37,10 @@ type GetProvidersFunc func() ([]Provider, error)
 
 func (ps providers) validate() error {
 	if len(ps) == 0 {
-		return &SetupError{Code: SetupErrorEmptyProviderCollection, Message: "The collection of providers must contain at least one element."}
+		return &SetupError{
+			Code:    SetupErrorEmptyProviderCollection,
+			Message: "The collection of providers must contain at least one element.",
+		}
 	}
 
 	for _, p := range ps {
@@ -63,7 +66,10 @@ func (p Provider) validate() error {
 
 func validateProviderIssuer(iss string) error {
 	if iss == "" {
-		return &SetupError{Code: SetupErrorInvalidIssuer, Message: "Empty string issuer not allowed."}
+		return &SetupError{
+			Code:    SetupErrorInvalidIssuer,
+			Message: "Empty string issuer not allowed.",
+		}
 	}
 
 	// TODO: Validate that the issuer format complies with openid spec.
@@ -72,7 +78,10 @@ func validateProviderIssuer(iss string) error {
 
 func validateProviderClientIDs(cIDs []string) error {
 	if len(cIDs) == 0 {
-		return &SetupError{Code: SetupErrorInvalidClientIDs, Message: "At leat one client id must be provided."}
+		return &SetupError{
+			Code:    SetupErrorInvalidClientIDs,
+			Message: "At leat one client id must be provided.",
+		}
 	}
 
 	return nil

--- a/openid/readidtoken.go
+++ b/openid/readidtoken.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// GetIdTokenFunc represents the function used to provide the OIDC idToken.
+// GetIDTokenFunc represents the function used to provide the OIDC idToken.
 // It uses the provided request(r) to return the id token string(token).
 // If the token was not found or had a bad format this function will return an error.
 type GetIDTokenFunc func(r *http.Request) (token string, err error)
@@ -17,17 +17,29 @@ type GetIDTokenFunc func(r *http.Request) (token string, err error)
 func getIDTokenAuthorizationHeader(r *http.Request) (t string, err error) {
 	h := r.Header.Get("Authorization")
 	if h == "" {
-		return h, &ValidationError{Code: ValidationErrorAuthorizationHeaderNotFound, Message: "The 'Authorization' header was not found or was empty.", HTTPStatus: http.StatusBadRequest}
+		return h, &ValidationError{
+			Code:       ValidationErrorAuthorizationHeaderNotFound,
+			Message:    "The 'Authorization' header was not found or was empty.",
+			HTTPStatus: http.StatusBadRequest,
+		}
 	}
 
 	p := strings.Split(h, " ")
 
 	if len(p) != 2 {
-		return h, &ValidationError{Code: ValidationErrorAuthorizationHeaderWrongFormat, Message: "The 'Authorization' header did not have the correct format.", HTTPStatus: http.StatusBadRequest}
+		return h, &ValidationError{
+			Code:       ValidationErrorAuthorizationHeaderWrongFormat,
+			Message:    "The 'Authorization' header did not have the correct format.",
+			HTTPStatus: http.StatusBadRequest,
+		}
 	}
 
 	if p[0] != "Bearer" {
-		return h, &ValidationError{Code: ValidationErrorAuthorizationHeaderWrongSchemeName, Message: "The 'Authorization' header scheme name was not 'Bearer'", HTTPStatus: http.StatusBadRequest}
+		return h, &ValidationError{
+			Code:       ValidationErrorAuthorizationHeaderWrongSchemeName,
+			Message:    "The 'Authorization' header scheme name was not 'Bearer'",
+			HTTPStatus: http.StatusBadRequest,
+		}
 	}
 
 	return p[1], nil

--- a/openid/signingkeyencoder.go
+++ b/openid/signingkeyencoder.go
@@ -12,7 +12,12 @@ type pemEncodeFunc func(key interface{}) ([]byte, error)
 func pemEncodePublicKey(key interface{}) ([]byte, error) {
 	mk, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {
-		return nil, &ValidationError{Code: ValidationErrorMarshallingKey, Message: fmt.Sprint("The jwk key could not be marshalled."), HTTPStatus: http.StatusInternalServerError, Err: err}
+		return nil, &ValidationError{
+			Code:       ValidationErrorMarshallingKey,
+			Message:    fmt.Sprint("The jwk key could not be marshalled."),
+			Err:        err,
+			HTTPStatus: http.StatusInternalServerError,
+		}
 	}
 
 	ed := pem.EncodeToMemory(&pem.Block{

--- a/openid/signingkeygettermock_test.go
+++ b/openid/signingkeygettermock_test.go
@@ -1,6 +1,9 @@
 package openid
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
 type signingKeyGetterMock struct {
 	t     *testing.T
@@ -29,7 +32,7 @@ type flushCachedSigningKeysResp struct {
 	err error
 }
 
-func (s *signingKeyGetterMock) getSigningKey(iss string, keyID string) ([]byte, error) {
+func (s *signingKeyGetterMock) getSigningKey(r *http.Request, iss string, keyID string) ([]byte, error) {
 	s.Calls <- &getSigningKeyCall{iss, keyID}
 	sr := (<-s.Calls).(*getSigningKeyResp)
 	return sr.key, sr.err

--- a/openid/signingkeygettermock_test.go
+++ b/openid/signingkeygettermock_test.go
@@ -15,6 +15,7 @@ func newSigningKeyGetterMock(t *testing.T) *signingKeyGetterMock {
 }
 
 type getSigningKeyCall struct {
+	req   *http.Request
 	iss   string
 	keyID string
 }
@@ -33,7 +34,7 @@ type flushCachedSigningKeysResp struct {
 }
 
 func (s *signingKeyGetterMock) getSigningKey(r *http.Request, iss string, keyID string) ([]byte, error) {
-	s.Calls <- &getSigningKeyCall{iss, keyID}
+	s.Calls <- &getSigningKeyCall{r, iss, keyID}
 	sr := (<-s.Calls).(*getSigningKeyResp)
 	return sr.key, sr.err
 }
@@ -44,8 +45,11 @@ func (s *signingKeyGetterMock) flushCachedSigningKeys(iss string) error {
 	return sr.err
 }
 
-func (s *signingKeyGetterMock) assertGetSigningKey(iss string, keyID string, key []byte, err error) {
+func (s *signingKeyGetterMock) assertGetSigningKey(req *http.Request, iss string, keyID string, key []byte, err error) {
 	call := (<-s.Calls).(*getSigningKeyCall)
+	if req == nil || call.req != req {
+		s.t.Error("Expected getSigningKey with req", req, "but was", call.req)
+	}
 	if iss != anything && call.iss != iss {
 		s.t.Error("Expected getSigningKey with issuer", iss, "but was", call.iss)
 	}

--- a/openid/signingkeygettermock_test.go
+++ b/openid/signingkeygettermock_test.go
@@ -47,7 +47,7 @@ func (s *signingKeyGetterMock) flushCachedSigningKeys(iss string) error {
 
 func (s *signingKeyGetterMock) assertGetSigningKey(req *http.Request, iss string, keyID string, key []byte, err error) {
 	call := (<-s.Calls).(*getSigningKeyCall)
-	if req == nil || call.req != req {
+	if call.req != req {
 		s.t.Error("Expected getSigningKey with req", req, "but was", call.req)
 	}
 	if iss != anything && call.iss != iss {

--- a/openid/signingkeyprovider.go
+++ b/openid/signingkeyprovider.go
@@ -66,11 +66,10 @@ func findKey(km map[string][]signingKey, issuer string, kid string) []byte {
 	if skSet, ok := km[issuer]; ok {
 		if kid == "" {
 			return skSet[0].key
-		} else {
-			for _, sk := range skSet {
-				if sk.keyID == kid {
-					return sk.key
-				}
+		}
+		for _, sk := range skSet {
+			if sk.keyID == kid {
+				return sk.key
 			}
 		}
 	}

--- a/openid/signingkeyprovider_test.go
+++ b/openid/signingkeyprovider_test.go
@@ -48,7 +48,7 @@ func Test_getSigningKey_WhenProviderReturnsError(t *testing.T) {
 		keyGetter.close()
 	}()
 
-	rk, re := keyCache.getSigningKey(iss, kid)
+	rk, re := keyCache.getSigningKey(nil, iss, kid)
 
 	expectValidationError(t, re, ee.Code, ee.HTTPStatus, nil)
 
@@ -77,7 +77,7 @@ func Test_getSigningKey_WhenKeyIsNotFound(t *testing.T) {
 		keyGetter.close()
 	}()
 
-	rk, re := keyCache.getSigningKey(iss, tkid)
+	rk, re := keyCache.getSigningKey(nil, iss, tkid)
 
 	expectValidationError(t, re, ValidationErrorKidNotFound, http.StatusUnauthorized, nil)
 
@@ -167,7 +167,7 @@ func expectCachedKid(t *testing.T, keyProv *signingKeyProvider, iss string, kid 
 
 func expectKey(t *testing.T, c signingKeyGetter, iss string, kid string, key string) {
 
-	sk, re := c.getSigningKey(iss, kid)
+	sk, re := c.getSigningKey(nil, iss, kid)
 
 	if re != nil {
 		t.Error("An error was returned but not expected.")

--- a/openid/signingkeysetgettermock_test.go
+++ b/openid/signingkeysetgettermock_test.go
@@ -1,6 +1,9 @@
 package openid
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
 type signingKeySetGetterMock struct {
 	t     *testing.T
@@ -20,7 +23,7 @@ type getSigningKeySetResponse struct {
 	err  error
 }
 
-func (c *signingKeySetGetterMock) getSigningKeySet(iss string) ([]signingKey, error) {
+func (c *signingKeySetGetterMock) getSigningKeySet(r *http.Request, iss string) ([]signingKey, error) {
 	c.Calls <- &getSigningKeySetCall{iss}
 	sr := (<-c.Calls).(*getSigningKeySetResponse)
 	return sr.keys, sr.err

--- a/openid/signingkeysetprovider.go
+++ b/openid/signingkeysetprovider.go
@@ -31,14 +31,18 @@ func (signProv *signingKeySetProvider) getSigningKeySet(r *http.Request, iss str
 		return nil, err
 	}
 
-	jwks, err := signProv.jwksGetter.getJwkSet(r, conf.JwksUri)
+	jwks, err := signProv.jwksGetter.getJwkSet(r, conf.JwksURI)
 
 	if err != nil {
 		return nil, err
 	}
 
 	if len(jwks.Keys) == 0 {
-		return nil, &ValidationError{Code: ValidationErrorEmptyJwk, Message: fmt.Sprintf("The jwk set retrieved for the issuer %v does not contain any key.", iss), HTTPStatus: http.StatusUnauthorized}
+		return nil, &ValidationError{
+			Code:       ValidationErrorEmptyJwk,
+			Message:    fmt.Sprintf("The jwk set retrieved for the issuer %v does not contain any key.", iss),
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	sk := make([]signingKey, len(jwks.Keys))

--- a/openid/signingkeysetprovider.go
+++ b/openid/signingkeysetprovider.go
@@ -6,7 +6,7 @@ import (
 )
 
 type signingKeySetGetter interface {
-	getSigningKeySet(issuer string) ([]signingKey, error)
+	getSigningKeySet(r *http.Request, issuer string) ([]signingKey, error)
 }
 
 type signingKeySetProvider struct {
@@ -24,14 +24,14 @@ func newSigningKeySetProvider(cg configurationGetter, jg jwksGetter, ke pemEncod
 	return &signingKeySetProvider{cg, jg, ke}
 }
 
-func (signProv *signingKeySetProvider) getSigningKeySet(iss string) ([]signingKey, error) {
-	conf, err := signProv.configGetter.getConfiguration(iss)
+func (signProv *signingKeySetProvider) getSigningKeySet(r *http.Request, iss string) ([]signingKey, error) {
+	conf, err := signProv.configGetter.getConfiguration(r, iss)
 
 	if err != nil {
 		return nil, err
 	}
 
-	jwks, err := signProv.jwksGetter.getJwkSet(conf.JwksUri)
+	jwks, err := signProv.jwksGetter.getJwkSet(r, conf.JwksUri)
 
 	if err != nil {
 		return nil, err

--- a/openid/signingkeysetprovider_test.go
+++ b/openid/signingkeysetprovider_test.go
@@ -18,7 +18,7 @@ func Test_getsigningKeySet_WhenGetConfigurationReturnsError(t *testing.T) {
 		configGetter.close()
 	}()
 
-	sk, re := skProv.getSigningKeySet(anything)
+	sk, re := skProv.getSigningKeySet(nil, anything)
 
 	expectValidationError(t, re, ee.Code, ee.HTTPStatus, nil)
 
@@ -42,7 +42,7 @@ func Test_getsigningKeySet_WhenGetJwksReturnsError(t *testing.T) {
 
 	}()
 
-	sk, re := skProv.getSigningKeySet(anything)
+	sk, re := skProv.getSigningKeySet(nil, anything)
 
 	expectValidationError(t, re, ee.Code, ee.HTTPStatus, nil)
 
@@ -67,7 +67,7 @@ func Test_getsigningKeySet_WhenJwkSetIsEmpty(t *testing.T) {
 
 	}()
 
-	sk, re := skProv.getSigningKeySet(anything)
+	sk, re := skProv.getSigningKeySet(nil, anything)
 
 	expectValidationError(t, re, ee.Code, ee.HTTPStatus, nil)
 
@@ -94,7 +94,7 @@ func Test_getsigningKeySet_WhenKeyEncodingReturnsError(t *testing.T) {
 		pemEncoder.close()
 	}()
 
-	sk, re := skProv.getSigningKeySet(anything)
+	sk, re := skProv.getSigningKeySet(nil, anything)
 
 	expectValidationError(t, re, ee.Code, ee.HTTPStatus, nil)
 
@@ -130,7 +130,7 @@ func Test_getsigningKeySet_WhenKeyEncodingReturnsSuccess(t *testing.T) {
 		pemEncoder.close()
 	}()
 
-	sk, re := skProv.getSigningKeySet(anything)
+	sk, re := skProv.getSigningKeySet(nil, anything)
 
 	if re != nil {
 		t.Error("An error was returned but not expected.")

--- a/openid/signingkeysetprovider_test.go
+++ b/openid/signingkeysetprovider_test.go
@@ -58,19 +58,18 @@ func Test_getsigningKeySet_WhenGetJwksReturnsError(t *testing.T) {
 
 func Test_getsigningKeySet_WhenJwkSetIsEmpty(t *testing.T) {
 	configGetter, jwksGetter, _, skProv := createSigningKeySetProvider(t)
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	ee := &ValidationError{Code: ValidationErrorEmptyJwk, HTTPStatus: http.StatusUnauthorized}
 
 	go func() {
 		configGetter.assertGetConfiguration(anything, configuration{}, nil)
 		configGetter.close()
-		jwksGetter.assertGetJwks(req, anything, jose.JsonWebKeySet{}, nil)
+		jwksGetter.assertGetJwks(nil, anything, jose.JsonWebKeySet{}, nil)
 		jwksGetter.close()
 
 	}()
 
-	sk, re := skProv.getSigningKeySet(req, anything)
+	sk, re := skProv.getSigningKeySet(nil, anything)
 
 	expectValidationError(t, re, ee.Code, ee.HTTPStatus, nil)
 
@@ -84,7 +83,6 @@ func Test_getsigningKeySet_WhenJwkSetIsEmpty(t *testing.T) {
 
 func Test_getsigningKeySet_WhenKeyEncodingReturnsError(t *testing.T) {
 	configGetter, jwksGetter, pemEncoder, skProv := createSigningKeySetProvider(t)
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	ee := &ValidationError{Code: ValidationErrorMarshallingKey, HTTPStatus: http.StatusInternalServerError}
 	ejwks := jose.JsonWebKeySet{Keys: []jose.JsonWebKey{{Key: nil}}}
@@ -92,13 +90,13 @@ func Test_getsigningKeySet_WhenKeyEncodingReturnsError(t *testing.T) {
 	go func() {
 		configGetter.assertGetConfiguration(anything, configuration{}, nil)
 		configGetter.close()
-		jwksGetter.assertGetJwks(req, anything, ejwks, nil)
+		jwksGetter.assertGetJwks(nil, anything, ejwks, nil)
 		jwksGetter.close()
 		pemEncoder.assertPEMEncodePublicKey(nil, nil, ee)
 		pemEncoder.close()
 	}()
 
-	sk, re := skProv.getSigningKeySet(req, anything)
+	sk, re := skProv.getSigningKeySet(nil, anything)
 
 	expectValidationError(t, re, ee.Code, ee.HTTPStatus, nil)
 

--- a/openid/user.go
+++ b/openid/user.go
@@ -21,19 +21,31 @@ type User struct {
 
 func newUser(t *jwt.Token) (*User, error) {
 	if t == nil {
-		return nil, &ValidationError{Code: ValidationErrorIdTokenEmpty, Message: "The token provided to created a user was nil.", HTTPStatus: http.StatusUnauthorized}
+		return nil, &ValidationError{
+			Code:       ValidationErrorIdTokenEmpty,
+			Message:    "The token provided to created a user was nil.",
+			HTTPStatus: http.StatusUnauthorized,
+		}
 	}
 
 	iss := getIssuer(t).(string)
 
 	if iss == "" {
-		return nil, &ValidationError{Code: ValidationErrorInvalidIssuer, Message: "The token provided to created a user did not contain a valid 'iss' claim", HTTPStatus: http.StatusInternalServerError}
+		return nil, &ValidationError{
+			Code:       ValidationErrorInvalidIssuer,
+			Message:    "The token provided to created a user did not contain a valid 'iss' claim",
+			HTTPStatus: http.StatusInternalServerError,
+		}
 	}
 
 	sub := getSubject(t).(string)
 
 	if sub == "" {
-		return nil, &ValidationError{Code: ValidationErrorInvalidSubject, Message: "The token provided to created a user did not contain a valid 'sub' claim.", HTTPStatus: http.StatusInternalServerError}
+		return nil, &ValidationError{
+			Code:       ValidationErrorInvalidSubject,
+			Message:    "The token provided to created a user did not contain a valid 'sub' claim.",
+			HTTPStatus: http.StatusInternalServerError,
+		}
 
 	}
 

--- a/openid/userhandler.go
+++ b/openid/userhandler.go
@@ -16,7 +16,7 @@ type UserHandler interface {
 // This is similar to using http.HandlerFunc as http.Handler
 type UserHandlerFunc func(*User, http.ResponseWriter, *http.Request)
 
-// ServeHttpWithUser calls f(u, w, r)
+// ServeHTTPWithUser calls f(u, w, r)
 func (f UserHandlerFunc) ServeHTTPWithUser(u *User, w http.ResponseWriter, r *http.Request) {
 	f(u, w, r)
 }


### PR DESCRIPTION
This PR implements the configuration functionality needed to support the use of this library on Google App Engine, which is not capable of using the standard `net/http` library in Golang. The issue is documented here: https://github.com/emanoelxavier/openid2go/issues/9

This PR is implemented in the simplest possible way, with only internal changes being made to the codebase, except for an additional `HTTPGetter` configuration function.

It might be more idiomatic to use the `context` package rather than passing the literal request around in each method header, but since that `context` isn't currently used, this implementation seemed to make the most sense for now.